### PR TITLE
fix: anchors in blog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
                 "@11ty/eleventy-img": "^2.0.1",
                 "@11ty/eleventy-plugin-rss": "^1.2.0",
                 "@11ty/eleventy-plugin-syntaxhighlight": "^4.1.0",
-                "@sindresorhus/slugify": "^2.1.0",
+                "@sindresorhus/slugify": "^1.1.2",
                 "autoprefixer": "^10.4.11",
                 "editorconfig-checker": "4.0.0",
                 "esbuild": "^0.15.8",
@@ -313,59 +313,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/11ty"
-            }
-        },
-        "node_modules/@11ty/eleventy/node_modules/@sindresorhus/slugify": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-1.1.2.tgz",
-            "integrity": "sha512-V9nR/W0Xd9TSGXpZ4iFUcFGhuOJtZX82Fzxj1YISlbSgKvIiNa7eLEZrT0vAraPOt++KHauIVNYgGRgjc13dXA==",
-            "dev": true,
-            "dependencies": {
-                "@sindresorhus/transliterate": "^0.1.1",
-                "escape-string-regexp": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@11ty/eleventy/node_modules/@sindresorhus/transliterate": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/transliterate/-/transliterate-0.1.2.tgz",
-            "integrity": "sha512-5/kmIOY9FF32nicXH+5yLNTX4NJ4atl7jRgqAJuIn/iyDFXBktOKDxCvyGE/EzmF4ngSUvjXxQUQlQiZ5lfw+w==",
-            "dev": true,
-            "dependencies": {
-                "escape-string-regexp": "^2.0.0",
-                "lodash.deburr": "^4.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@11ty/eleventy/node_modules/@sindresorhus/transliterate/node_modules/escape-string-regexp": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-            "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@11ty/eleventy/node_modules/escape-string-regexp": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -714,35 +661,44 @@
             }
         },
         "node_modules/@sindresorhus/slugify": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-2.1.1.tgz",
-            "integrity": "sha512-XokPHZ+q6FtQGEi1hnfvARVJJVPEhwHQTPHPPuNHaN6zcHjzYNynhhHMopa1wNPqLAFOwpsbintunEqWecXJMg==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-1.1.2.tgz",
+            "integrity": "sha512-V9nR/W0Xd9TSGXpZ4iFUcFGhuOJtZX82Fzxj1YISlbSgKvIiNa7eLEZrT0vAraPOt++KHauIVNYgGRgjc13dXA==",
             "dev": true,
             "dependencies": {
-                "@sindresorhus/transliterate": "^1.0.0",
-                "escape-string-regexp": "^5.0.0"
+                "@sindresorhus/transliterate": "^0.1.1",
+                "escape-string-regexp": "^4.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/@sindresorhus/transliterate": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/transliterate/-/transliterate-1.5.0.tgz",
-            "integrity": "sha512-/sfSkoNelLq5riqNRp5uBjHIKBi1MWZk9ubRT1WiBQuTfmDf7BeQkph2DJzRB83QagMPHk2VDjuvpy0VuwyzdA==",
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/transliterate/-/transliterate-0.1.2.tgz",
+            "integrity": "sha512-5/kmIOY9FF32nicXH+5yLNTX4NJ4atl7jRgqAJuIn/iyDFXBktOKDxCvyGE/EzmF4ngSUvjXxQUQlQiZ5lfw+w==",
             "dev": true,
             "dependencies": {
-                "escape-string-regexp": "^5.0.0",
+                "escape-string-regexp": "^2.0.0",
                 "lodash.deburr": "^4.1.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@sindresorhus/transliterate/node_modules/escape-string-regexp": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+            "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/@types/eslint": {
@@ -2259,12 +2215,12 @@
             "dev": true
         },
         "node_modules/escape-string-regexp": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "dev": true,
             "engines": {
-                "node": ">=12"
+                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -2401,18 +2357,6 @@
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            }
-        },
-        "node_modules/eslint/node_modules/escape-string-regexp": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/eslint/node_modules/glob-parent": {
@@ -6473,42 +6417,6 @@
                 "recursive-copy": "^2.0.14",
                 "semver": "^7.3.7",
                 "slugify": "^1.6.5"
-            },
-            "dependencies": {
-                "@sindresorhus/slugify": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-1.1.2.tgz",
-                    "integrity": "sha512-V9nR/W0Xd9TSGXpZ4iFUcFGhuOJtZX82Fzxj1YISlbSgKvIiNa7eLEZrT0vAraPOt++KHauIVNYgGRgjc13dXA==",
-                    "dev": true,
-                    "requires": {
-                        "@sindresorhus/transliterate": "^0.1.1",
-                        "escape-string-regexp": "^4.0.0"
-                    }
-                },
-                "@sindresorhus/transliterate": {
-                    "version": "0.1.2",
-                    "resolved": "https://registry.npmjs.org/@sindresorhus/transliterate/-/transliterate-0.1.2.tgz",
-                    "integrity": "sha512-5/kmIOY9FF32nicXH+5yLNTX4NJ4atl7jRgqAJuIn/iyDFXBktOKDxCvyGE/EzmF4ngSUvjXxQUQlQiZ5lfw+w==",
-                    "dev": true,
-                    "requires": {
-                        "escape-string-regexp": "^2.0.0",
-                        "lodash.deburr": "^4.1.0"
-                    },
-                    "dependencies": {
-                        "escape-string-regexp": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-                            "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-                            "dev": true
-                        }
-                    }
-                },
-                "escape-string-regexp": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-                    "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-                    "dev": true
-                }
             }
         },
         "@11ty/eleventy-dev-server": {
@@ -6920,23 +6828,31 @@
             }
         },
         "@sindresorhus/slugify": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-2.1.1.tgz",
-            "integrity": "sha512-XokPHZ+q6FtQGEi1hnfvARVJJVPEhwHQTPHPPuNHaN6zcHjzYNynhhHMopa1wNPqLAFOwpsbintunEqWecXJMg==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-1.1.2.tgz",
+            "integrity": "sha512-V9nR/W0Xd9TSGXpZ4iFUcFGhuOJtZX82Fzxj1YISlbSgKvIiNa7eLEZrT0vAraPOt++KHauIVNYgGRgjc13dXA==",
             "dev": true,
             "requires": {
-                "@sindresorhus/transliterate": "^1.0.0",
-                "escape-string-regexp": "^5.0.0"
+                "@sindresorhus/transliterate": "^0.1.1",
+                "escape-string-regexp": "^4.0.0"
             }
         },
         "@sindresorhus/transliterate": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/transliterate/-/transliterate-1.5.0.tgz",
-            "integrity": "sha512-/sfSkoNelLq5riqNRp5uBjHIKBi1MWZk9ubRT1WiBQuTfmDf7BeQkph2DJzRB83QagMPHk2VDjuvpy0VuwyzdA==",
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/transliterate/-/transliterate-0.1.2.tgz",
+            "integrity": "sha512-5/kmIOY9FF32nicXH+5yLNTX4NJ4atl7jRgqAJuIn/iyDFXBktOKDxCvyGE/EzmF4ngSUvjXxQUQlQiZ5lfw+w==",
             "dev": true,
             "requires": {
-                "escape-string-regexp": "^5.0.0",
+                "escape-string-regexp": "^2.0.0",
                 "lodash.deburr": "^4.1.0"
+            },
+            "dependencies": {
+                "escape-string-regexp": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+                    "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+                    "dev": true
+                }
             }
         },
         "@types/eslint": {
@@ -7943,9 +7859,9 @@
             "dev": true
         },
         "escape-string-regexp": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "dev": true
         },
         "eslint": {
@@ -7995,12 +7911,6 @@
                 "text-table": "^0.2.0"
             },
             "dependencies": {
-                "escape-string-regexp": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-                    "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-                    "dev": true
-                },
                 "glob-parent": {
                     "version": "6.0.2",
                     "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "@11ty/eleventy-img": "^2.0.1",
         "@11ty/eleventy-plugin-rss": "^1.2.0",
         "@11ty/eleventy-plugin-syntaxhighlight": "^4.1.0",
-        "@sindresorhus/slugify": "^2.1.0",
+        "@sindresorhus/slugify": "^1.1.2",
         "autoprefixer": "^10.4.11",
         "editorconfig-checker": "4.0.0",
         "esbuild": "^0.15.8",

--- a/src/transforms/anchors.js
+++ b/src/transforms/anchors.js
@@ -1,4 +1,4 @@
-const slugify = require('slugify');
+const slugify = require('@sindresorhus/slugify');
 
 module.exports = function(window) {
     const content = window.document.getElementById('article-content');


### PR DESCRIPTION
Anchors with dots like `GOV.UK` not working – https://pepelsbey.dev/articles/conditionally-adaptive/#gov-uk

It's because `slugify` and `@sindresorhus/slugify` are similar libraries, but with different behavior (by the way there isn't `slugify` in deps :-)

**11ty** [uses `@sindresorhus/slugify`](https://www.11ty.dev/docs/filters/slugify/), so I used it too in `anchors.js`.

And downgraded its version to `1.x.x`, [because of ES modules](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c).