### PR TITLE
Make diff syntax highlight more readable

### DIFF
--- a/src/styles/blocks/prism/base.css
+++ b/src/styles/blocks/prism/base.css
@@ -59,18 +59,22 @@
 	.token.property,
 	.token.tag,
 	.token.symbol,
-	.token.deleted,
-	.token.important
+	.token.important,
+	.token.inserted
 ) {
 	color: var(--prism-green);
 }
 
 .prism :is(
+	.token.deleted
+) {
+	color: var(--prism-red);
+}
+.prism :is(
 	.token.selector,
 	.token.string,
 	.token.char,
 	.token.builtin,
-	.token.inserted,
 	.token.regex,
 	.token.attr-value,
 	.token.attr-value > .token.punctuation


### PR DESCRIPTION
Use red color for deleted nodes, greed – for added (like on GitHub).

GitHub Example:

```diff
-<div class="cta-button">Submit</div>
+<button type="submit" class="cta-button">Submit</button>
```