### PR TITLE
Improve title copying fix

### DIFF
--- a/src/scripts/modules/lead-copy.js
+++ b/src/scripts/modules/lead-copy.js
@@ -1,7 +1,15 @@
+function getSelectionTextContent() {
+	const selection = document.getSelection();
+	const range = selection?.getRangeAt(0);
+	const clone = range?.cloneContents();
+	return clone?.textContent;
+}
+
 document.querySelector('.lead__title')?.addEventListener('copy', (event) => {
+	const selectionText = getSelectionTextContent();
 	event.clipboardData.setData(
 		'text/plain',
-		event.target.textContent
+		selectionText ?? event.target.textContent
 	);
 
 	event.preventDefault();


### PR DESCRIPTION
After reading the article about the problem with copying transformed text, I thought that there is a [Selection API](https://developer.mozilla.org/en-US/docs/Web/API/Selection). A small change I made fixes copying parts of the title and any other content that is selected along with it.
I think this code would be reasonable to use for the entire document, not just the titles, but didn't make that change.